### PR TITLE
travis: Expand to include manifest

### DIFF
--- a/.travis-manifest.sh
+++ b/.travis-manifest.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -x -v
+if [ "$TRAVIS_EVENT_TYPE" != "pull_request" ] &&
+   [ "$TRAVIS_BRANCH" = "master" ]; then
+     mkdir -p ~/.docker
+     echo '{ "experimental" : "enabled" }' > ~/.docker/config.json
+     echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+     docker manifest create  "${REPO}:${RELEASE}" "${REPO}:linux" "${REPO}:windows" "${REPO}:linux_ppc64le"
+     docker manifest inspect "${REPO}:${RELEASE}"
+     docker manifest push    "${REPO}:${RELEASE}"
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,38 @@ language: shell
 services:
   - docker
 os:
-  - linux
   - windows
+  - linux-ppc64le
+  - linux
+
+env:
+  global:
+    - REPO="fsouza/go-dockerclient-integration"
+
 script:
-  - docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
-  - docker build -f Dockerfile.${TRAVIS_OS_NAME} -t fsouza/go-dockerclient-integration:${TRAVIS_OS_NAME} .
-  - docker push fsouza/go-dockerclient-integration
+  - |
+      if [ $(uname -m) = ppc64le ]; then
+        TAG=linux_ppc64le
+      else
+        TAG=${TRAVIS_OS_NAME}
+      fi
+  - docker build -f Dockerfile.${TRAVIS_OS_NAME} -t ${REPO}:${TAG} .
+
+after_success:
+  - |
+      if [ "$TRAVIS_EVENT_TYPE" != "pull_request" ] &&
+         [ "$TRAVIS_BRANCH" = "master" ]; then
+        docker images
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        docker push ${REPO}:${TAG}
+      fi
+
+jobs:
+  include:
+    - stage: build_multi_arch_docker_image_latest
+      os: linux-ppc64le
+      env: RELEASE=latest
+      before_install: true
+      install: true
+      after_success: true
+      script: ./.travis-manifest.sh


### PR DESCRIPTION
This pushes the :latest tag as a manifest to include multiple platforms.

We expand to include a ppc64le architecture at the same time.

For safety, docker login/push aren't enabled on pull requests or non-master branch. Environment variables are currently protected however this prevents failures on PRs.

The purpose is to include provide a test for go-dockerclient for docker API 1.34 "Create an Image" tests that has platform as an argument.

Example of it working (https://travis-ci.org/grooverdan/go-dockerclient-integration/builds/572132986), before I changed back to your REPO name.

ppc64le was used to build the manifest as it seemed to be the only one with a docker version 18.0X+ version (needed for manifest). Windows also worked but leaks passwords in the travis log.